### PR TITLE
Increase number of valid arguments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.org.gradle.internal.cmdline.max.length=131072


### PR DESCRIPTION
Some folks are experiencing the following problem:
```
engine codenarc failed with status 1 and stderr 
Caught: java.io.IOException: Cannot run program "java": error=7, Argument list too long
java.io.IOException: Cannot run program "java": error=7, Argument list too long
	at java_lang_ProcessBuilder$start$0.call(Unknown Source)
	at Main.execute(main.groovy:8)
	at Main$execute$0.callStatic(Unknown Source)
	at Main.main(main.groovy:37)
Caused by: java.io.IOException: error=7, Argument list too long
	... 4 more
```

this is an attempt to address that.